### PR TITLE
Fixed: Media routes and bad watchlist id

### DIFF
--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -480,8 +480,6 @@ components:
           properties:
             username:
               $ref: '#/components/schemas/Field'
-            password:
-              $ref: '#/components/schemas/Field'
 
     MediaRequest:
       type: object

--- a/api/src/controllers/watchlist_controler.rs
+++ b/api/src/controllers/watchlist_controler.rs
@@ -258,7 +258,7 @@ pub async fn get_watchlist_medias(
     match watchlist.get_media().await {
         Err(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            ResponseBody::error("Couldn\'t get the medias. Please contact the admin."),
+            ResponseBody::error("Couldn\'t get the media. Please contact the admin."),
         ),
         Ok(medias) => {
             info!("The medias were successfully retrieved.");

--- a/api/src/models/media_model.rs
+++ b/api/src/models/media_model.rs
@@ -161,7 +161,7 @@ impl From<MediaRequest> for Media {
             description: value.description,
             watchlist: Thing {
                 id: Id::from(value.watchlist),
-                tb: String::from("media"),
+                tb: String::from("watchlist"),
             },
             watched: value.watched,
             created_at: Datetime::default(),

--- a/api/src/router.rs
+++ b/api/src/router.rs
@@ -19,8 +19,8 @@ use crate::{
 pub fn get_router() -> Router {
     Router::new()
         .route("/media", post(post_media))
-        .route("/media", patch(patch_media))
-        .route("/media", delete(delete_media))
+        .route("/media/:media_id", patch(patch_media))
+        .route("/media/:media_id", delete(delete_media))
         .route("/media/:media_id", get(get_media))
         .route("/user", post(post_user))
         .route("/user", patch(patch_user))


### PR DESCRIPTION
The media router was incorrect without any model_id in the PATCH and DELETE methods. Also, the created medias were storing IDs from media